### PR TITLE
feat: use total_stake_token endpoints and add Indexing status banner

### DIFF
--- a/src/components/layouts/NetworkHealthBanner.tsx
+++ b/src/components/layouts/NetworkHealthBanner.tsx
@@ -22,11 +22,13 @@ export default function NetworkHealthBanner() {
       Normal: GreenCheck(),
       Degraded: YellowWarning({ cn: 'w-6 h-6' }),
       Down: RedAlert(),
+      Indexing: YellowWarning({ cn: 'w-6 h-6' }),
     },
     style: {
       Normal: 'border-white/[17%] bg-primary-grey',
       Degraded: 'border-[#E4CE07] bg-[#514903]',
       Down: 'border-[#EF7276] bg-[#4A030B]',
+      Indexing: 'border-[#60A5FA] bg-[#1E3A5F]',
     },
     text: {
       Normal: (
@@ -50,6 +52,11 @@ export default function NetworkHealthBanner() {
             X/Twitter
           </Link>{' '}
           for immediate updates.
+        </p>
+      ),
+      Indexing: (
+        <p className="">
+          Staking data is currently being indexed. Some information may be temporarily unavailable or outdated.
         </p>
       ),
     },

--- a/src/lib/services/api/networkApi.ts
+++ b/src/lib/services/api/networkApi.ts
@@ -95,7 +95,7 @@ export async function getNetworkStakingParams(): Promise<GetNetworkStakingParams
 export async function getNetworkTotalStakeHistory(
   params?: GetNetworkTotalStakeHistoryParams
 ): Promise<GetNetworkTotalStakeHistoryResponse> {
-  const response = await stakingDataAxios.get<GetNetworkTotalStakeHistoryApiResponse>('/staking/total_stake/history', {
+  const response = await stakingDataAxios.get<GetNetworkTotalStakeHistoryApiResponse>('/staking/total_stake_token/history', {
     params: {
       interval: params?.interval || '1d',
       ...params,
@@ -112,7 +112,7 @@ export async function getNetworkTotalStakeHistory(
 }
 
 export async function getNetworkTotalStake(): Promise<GetNetworkTotalStakeResponse> {
-  const response = await stakingDataAxios.get<GetNetworkTotalStakeApiResponse>('/staking/total_stake')
+  const response = await stakingDataAxios.get<GetNetworkTotalStakeApiResponse>('/staking/total_stake_token')
 
   if (response.status !== 200) {
     throw new Error(`Failed to get network total stake: ${response.status}`)

--- a/src/lib/types/networkApiTypes.ts
+++ b/src/lib/types/networkApiTypes.ts
@@ -17,7 +17,7 @@ export type GetNetworkHealthApiResponse = {
 export type GetNetworkHealthResponse = {
   consensus_block_height: number
   execution_block_height: number
-  status: 'Normal' | 'Pending' | 'Degraded' | 'Down'
+  status: 'Normal' | 'Pending' | 'Degraded' | 'Down' | 'Indexing'
 }
 
 export type EvmOperation = {


### PR DESCRIPTION
## Summary

- Replace deprecated `/staking/total_stake` and `/staking/total_stake/history` endpoints with `/staking/total_stake_token` and `/staking/total_stake_token/history`
- Add `Indexing` status handling in `NetworkHealthBanner` — displayed when the staking API indexer is still catching up to the chain tip